### PR TITLE
skip WinRM remote certificate validations

### DIFF
--- a/RemoteRetentionCleaner.ps1
+++ b/RemoteRetentionCleaner.ps1
@@ -10,10 +10,10 @@ Trace-VstsEnteringInvocation $MyInvocation
 [string]$remoteComputer = Get-VstsInput -Name "remoteComputer" -Require
 [string]$userName = Get-VstsInput -Name "userName" -Require
 [string]$password = Get-VstsInput -Name "password" -Require
-[string]$excludes = (Get-VstsInput -Name "excludes").Trim().Replace("`n",",")
+[string]$excludes = (Get-VstsInput -Name "excludes").Trim().Replace("`n", ",")
 [string]$winRMProtocol = Get-VstsInput -Name "winRMProtocol"
 
-Write-Host "Version 1.0.8"
+Write-Host "Version 1.0.10"
 Write-Host "remoteComputer = $remoteComputer"
 Write-Host "folderPath = $folderPath"
 Write-Host "retentionDays = $retentionDays"
@@ -26,50 +26,42 @@ Write-Host "winRMProtocol = $winRMProtocol"
 $portNumber = 5985;
 $sslArg = $false;
 
-if([string]::IsNullOrWhiteSpace($folderPath) ) 
-{  
+if ([string]::IsNullOrWhiteSpace($folderPath) ) {  
     throw [System.ArgumentException] "Folder path required"
     exit
 }
 
-if([string]::IsNullOrWhiteSpace($retentionDays) ) 
-{            
+if ([string]::IsNullOrWhiteSpace($retentionDays) ) {            
     throw [System.ArgumentException] "Rentention days required"
     exit
 }
 
 
-if([string]::IsNullOrWhiteSpace($minimumToKeep) ) 
-{            
-   throw [System.ArgumentException] "Minimum to keep is required"
+if ([string]::IsNullOrWhiteSpace($minimumToKeep) ) {            
+    throw [System.ArgumentException] "Minimum to keep is required"
     exit
 }
 
-if([string]::IsNullOrWhiteSpace($remoteComputer) ) 
-{            
+if ([string]::IsNullOrWhiteSpace($remoteComputer) ) {            
     throw [System.ArgumentException] "Remote computer is required"
     exit
 }
 
-if([string]::IsNullOrWhiteSpace($userName) ) 
-{            
+if ([string]::IsNullOrWhiteSpace($userName) ) {            
     throw [System.ArgumentException] "Username is required"
     exit
 }
 
-if([string]::IsNullOrWhiteSpace($password) ) 
-{
-  throw [System.ArgumentException] "Password is required"
-  exit
+if ([string]::IsNullOrWhiteSpace($password) ) {
+    throw [System.ArgumentException] "Password is required"
+    exit
 }
 
-if(-not [string]::IsNullOrWhiteSpace($winRMProtocol) ) 
-{  
-	if ($winRMProtocol -eq "Https") 
-	{ 
-		$portNumber = 5986;
-		$sslArg = $true;
-	}
+if (-not [string]::IsNullOrWhiteSpace($winRMProtocol) ) {  
+    if ($winRMProtocol -eq "Https") { 
+        $portNumber = 5986;
+        $sslArg = $true;
+    }
 }
 
 $script = { 
@@ -79,67 +71,62 @@ $script = {
 			 $minimumToKeep = $args[2]
 			 $excludes = $args[3]
 
-	$folderlist = Get-ChildItem $folderPath -Exclude $excludes.Split(",") | sort @{Expression={$_.LastWriteTime}; Ascending=$false}
-	Write-Host "Item list : "
-	Write-Host $folderlist
+    $folderlist = Get-ChildItem $folderPath -Exclude $excludes.Split(",") | sort @{Expression = {$_.LastWriteTime}; Ascending = $false}
+    Write-Host "Item list : "
+    Write-Host $folderlist
 	
-	$keepDate = (Get-Date).AddDays(-$retentionDays)
-	$keeping = 0
+    $keepDate = (Get-Date).AddDays( - $retentionDays)
+    $keeping = 0
     $deleting = 0
 
-	ForEach ($folder In $folderlist) {
+    ForEach ($folder In $folderlist) {
 		
-		if($folder.LastWriteTime -lt $keepDate -And $minimumToKeep -le $keeping)
-		{
-		   Write-Host "Deleting $($folder.FullName)"
-		   Remove-Item $folder.FullName -Recurse -Force
-		   $deleting++
+        if ($folder.LastWriteTime -lt $keepDate -And $minimumToKeep -le $keeping) {
+            Write-Host "Deleting $($folder.FullName)"
+            Remove-Item $folder.FullName -Recurse -Force
+            $deleting++
         }
-		else
-		{
-			$keeping++
-		}
-	}
+        else {
+            $keeping++
+        }
+    }
 
-     Write-Host "Deleting $($deleting) files/folders."
-	 Write-Host "Keeping $($keeping) files/folders."
+    Write-Host "Deleting $($deleting) files/folders."
+    Write-Host "Keeping $($keeping) files/folders."
 }
 
-$computers = $remoteComputer.split(',',[System.StringSplitOptions]::RemoveEmptyEntries)
-if($computers.Count -eq 0)
-  {  Write-Error "No remote computer"}
+$computers = $remoteComputer.split(',', [System.StringSplitOptions]::RemoveEmptyEntries)
+if ($computers.Count -eq 0)
+{  Write-Error "No remote computer"}
    
-$errors =@()
+$errors = @()
 
-foreach($computer in $computers)
-{
-	Try
-	{
-		Write-Host "Start process. Computer name : $($computer)."
-		Write-Host "	- PSCredential"
-		$credential = New-Object System.Management.Automation.PSCredential($userName, (ConvertTo-SecureString -String $password -AsPlainText -Force));
-		Write-Host "	- Initialize New-PSSession"
-		$session = New-PSSession -ComputerName $computer -Credential $credential -Port $portNumber -UseSSL:$sslArg;
+foreach ($computer in $computers) {
+    Try {
+        Write-Host "Start process. Computer name : $($computer)."
+        Write-Host "	- PSCredential"
+        $credential = New-Object System.Management.Automation.PSCredential($userName, (ConvertTo-SecureString -String $password -AsPlainText -Force));
+        # skip WinRM HTTPS certificates checks
+        $so = New-PsSessionOption -SkipCACheck -SkipCNCheck -SkipRevocationCheck
+        Write-Host "	- Initialize New-PSSession"
+        $session = New-PSSession -ComputerName $computer -Credential $credential -Port $portNumber -SessionOption $so -UseSSL:$sslArg;
 
-		Write-Host "	- Invoke-Command"
-		Invoke-Command -Session $session -ScriptBlock $script -ArgumentList $folderPath, $retentionDays ,$minimumToKeep, $excludes
-		Write-Host "	- Remove-PSSession"
-		Remove-PSSession -Session $session
-	}
-	Catch
-	{			
-		$errors += @($computer + " " + $_.Exception.Message)
-	}		
+        Write-Host "	- Invoke-Command"
+        Invoke-Command -Session $session -ScriptBlock $script -ArgumentList $folderPath, $retentionDays , $minimumToKeep, $excludes
+        Write-Host "	- Remove-PSSession"
+        Remove-PSSession -Session $session
+    }
+    Catch {			
+        $errors += @($computer + " " + $_.Exception.Message)
+    }		
 }	
 
-if($errors.Count -ne 0)
-{
-	foreach( $er in $errors)
-	{
-		Write-Warning $er
-	}
+if ($errors.Count -ne 0) {
+    foreach ( $er in $errors) {
+        Write-Warning $er
+    }
 	
-	throw "$($errors.Count) errors in process. See logs"
+    throw "$($errors.Count) errors in process. See logs"
 }
 
 

--- a/task.json
+++ b/task.json
@@ -1,89 +1,96 @@
 {
-    "id":  "15f76a08-0248-4dc8-b93e-960a7c8e69c7",
-    "name":  "RemoteRetentionCleaner",
-    "friendlyName":  "Windows Remote Retention Cleaner",
-    "description":  "Windows Remote cleaner with retention policy.",
-    "category":  "Utility",
-	"visibility": [
-		"Build",
-		"Release"
-	],
-    "author":  "deka",
-    "version":  {
-                    "Major":  1,
-                    "Minor":  0,
-                    "Patch":  9
-                },
-    "minimumAgentVersion":  "1.83.0",
-    "inputs":  [
-                   {
-                       "name":  "remoteComputer",
-                       "type":  "string",
-                       "label":  "Remote computers",
-                       "defaultValue":  "",
-                       "required":  true,
-                       "helpMarkDown":  "The names of windows machines separated by commas. ex : MACHINE1,MACHINE2."
-                   },{
-                       "name":  "userName",
-                       "type":  "string",
-                       "label":  "User name",
-                       "defaultValue":  "",
-                       "required":  true,
-                       "helpMarkDown":  "The user name for credential."
-                   },{
-                       "name":  "password",
-                       "type":  "string",
-                       "label":  "Password",
-                       "defaultValue":  "",
-                       "required":  true,
-                       "helpMarkDown":  "The password for credential."
-                   },{
-                       "name":  "folderPath",
-                       "type":  "string",
-                       "label":  "Path",
-                       "defaultValue":  "",
-                       "required":  true,
-                       "helpMarkDown":  "The path to the folder that needs to be cleaned."
-                   },{
-					   "name":  "excludes",
-                       "type":  "multiLine",
-                       "label":  "Omits the specified items",
-                       "defaultValue":  "",
-                       "required":  false,
-                       "helpMarkDown":  "Omits the specified items. The value of this parameter qualifies the Path parameter. Enter a path element or pattern, such as '*.txt'. Wildcards are permitted. You can use line break or comma to add multiple patterns"
-				   },{
-                       "name":  "retentionDays",
-                       "type":  "string",
-                       "label":  "Days to keep",
-                       "defaultValue":  "30",
-                       "required":  true,
-                       "helpMarkDown":  "Retention days."
-                   },{
-                       "name":  "minimumToKeep",
-                       "type":  "string",
-                       "label":  "Minimum to keep",
-                       "defaultValue":  "2",
-                       "required":  true,
-                       "helpMarkDown":  "Minimum to keep."
-                   },{
-                        "name": "winRMProtocol",
-                        "type": "radio",
-                        "label": "Protocol",
-                        "required": false,
-                        "defaultValue": "Http",
-                        "options": {
-                        "Http": "HTTP",
-                        "Https": "HTTPS"
-                    },
-                    "helpMarkDown": "Select the network protocol to use for the WinRM connection with the machine(s). The default is HTTP."
-                }				   
-               ],
-    "instanceNameFormat":  "Remote cleaner $(remoteComputer) $(folderPath).",
-    "execution":  {
-                      "PowerShell3":  {
-                                          "target":  "$(currentDirectory)\\RemoteRetentionCleaner.ps1",
-                                          "argumentFormat":  "",
-                                          "workingDirectory":  "$(currentDirectory)"
-                                      }
-                  }
+  "id": "15f76a08-0248-4dc8-b93e-960a7c8e69c7",
+  "name": "RemoteRetentionCleaner",
+  "friendlyName": "Windows Remote Retention Cleaner",
+  "description": "Windows Remote cleaner with retention policy.",
+  "category": "Utility",
+  "visibility": ["Build", "Release"],
+  "author": "deka",
+  "version": {
+    "Major": 1,
+    "Minor": 0,
+    "Patch": 10
+  },
+  "minimumAgentVersion": "1.83.0",
+  "inputs": [
+    {
+      "name": "remoteComputer",
+      "type": "string",
+      "label": "Remote computers",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown":
+        "The names of windows machines separated by commas. ex : MACHINE1,MACHINE2."
+    },
+    {
+      "name": "userName",
+      "type": "string",
+      "label": "User name",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "The user name for credential."
+    },
+    {
+      "name": "password",
+      "type": "string",
+      "label": "Password",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "The password for credential."
+    },
+    {
+      "name": "folderPath",
+      "type": "string",
+      "label": "Path",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "The path to the folder that needs to be cleaned."
+    },
+    {
+      "name": "excludes",
+      "type": "multiLine",
+      "label": "Omits the specified items",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown":
+        "Omits the specified items. The value of this parameter qualifies the Path parameter. Enter a path element or pattern, such as '*.txt'. Wildcards are permitted. You can use line break or comma to add multiple patterns"
+    },
+    {
+      "name": "retentionDays",
+      "type": "string",
+      "label": "Days to keep",
+      "defaultValue": "30",
+      "required": true,
+      "helpMarkDown": "Retention days."
+    },
+    {
+      "name": "minimumToKeep",
+      "type": "string",
+      "label": "Minimum to keep",
+      "defaultValue": "2",
+      "required": true,
+      "helpMarkDown": "Minimum to keep."
+    },
+    {
+      "name": "winRMProtocol",
+      "type": "radio",
+      "label": "Protocol",
+      "required": false,
+      "defaultValue": "Http",
+      "options": {
+        "Http": "HTTP",
+        "Https": "HTTPS"
+      },
+      "helpMarkDown":
+        "Select the network protocol to use for the WinRM connection with the machine(s). The default is HTTP."
+    }
+  ],
+  "instanceNameFormat": "Remote cleaner $(remoteComputer) $(folderPath).",
+  "execution": {
+    "PowerShell3": {
+      "target": "$(currentDirectory)\\RemoteRetentionCleaner.ps1",
+      "argumentFormat": "",
+      "workingDirectory": "$(currentDirectory)"
+    }
+  }
 }


### PR DESCRIPTION
First of all, thanks for this!

Second, I am using the script to remotely delete files on a Server that is not joined to my domain (so contacting by IP address), which requires HTTPS mode - all fine but the Remote Certificate is a self signed one and as such I receive such errors:

```
Connecting to remote server xxx failed with the following error message : The server certificate on the destination computer (xx:5986) has the following errors: 
 
The SSL certificate could not be checked for revocation. The server used to check for revocation might be unreachable.    
 
The SSL certificate is signed by an unknown certificate authority.  
 
The SSL certificate contains a common name (CN) that does not match the hostname. For more information, see the about_Remote_Troubleshooting Help topic.
```
 
I've also updated your Task's version number, but unfortunately I do not know how to package it since there is no `vss-extension.json`, so I am hoping you'll accept this PR and push an update to the Market.

Thanks in advance